### PR TITLE
Remove requiresBaseConversion from ValueConversion

### DIFF
--- a/src/QueryPlatform/AbstractQueryPlatform.php
+++ b/src/QueryPlatform/AbstractQueryPlatform.php
@@ -218,11 +218,6 @@ abstract class AbstractQueryPlatform implements QueryPlatformInterface
 
         $convertedValue = $value;
         $hints = $this->getConversionHints($fieldName, $column, $strategy);
-
-        if ($converter->requiresBaseConversion($value, $options, $hints)) {
-            $convertedValue = $type->convertToDatabaseValue($value, $this->connection->getDatabasePlatform());
-        }
-
         $convertedValue = $converter->convertValue($convertedValue, $options, $hints);
 
         if ($converter instanceof SqlValueConversionInterface) {

--- a/src/ValueConversionInterface.php
+++ b/src/ValueConversionInterface.php
@@ -19,20 +19,6 @@ namespace Rollerworks\Component\Search\Doctrine\Dbal;
 interface ValueConversionInterface
 {
     /**
-     * Returns whether the base-conversion of the value is required.
-     *
-     * The base conversion uses the convertToDatabaseValue()
-     * of the database type.
-     *
-     * @param string          $input   Input value
-     * @param array           $options Options of the Field configuration
-     * @param ConversionHints $hints   Special information for the conversion process
-     *
-     * @return bool
-     */
-    public function requiresBaseConversion($input, array $options, ConversionHints $hints);
-
-    /**
      * Returns the converted input.
      *
      * @param mixed           $input   Input value

--- a/tests/Functional/WhereBuilderTest.php
+++ b/tests/Functional/WhereBuilderTest.php
@@ -352,12 +352,6 @@ final class WhereBuilderTest extends FunctionalDbalTestCase
 
         $converter
             ->expects($this->atLeastOnce())
-            ->method('requiresBaseConversion')
-            ->will($this->returnValue(false))
-        ;
-
-        $converter
-            ->expects($this->atLeastOnce())
             ->method('convertValue')
             ->will($this->returnArgument(0))
         ;

--- a/tests/Stub/Type/Doctrine/Conversion/InvoiceLabelConverter.php
+++ b/tests/Stub/Type/Doctrine/Conversion/InvoiceLabelConverter.php
@@ -16,11 +16,6 @@ use Rollerworks\Component\Search\Doctrine\Dbal\ValueConversionInterface;
 
 final class InvoiceLabelConverter implements ValueConversionInterface
 {
-    public function requiresBaseConversion($input, array $options, ConversionHints $hints)
-    {
-        return false;
-    }
-
     public function convertValue($input, array $options, ConversionHints $hints)
     {
         return (string) $input;

--- a/tests/WhereBuilderTest.php
+++ b/tests/WhereBuilderTest.php
@@ -488,12 +488,6 @@ final class WhereBuilderTest extends DbalTestCase
 
         $converter
             ->expects($this->atLeastOnce())
-            ->method('requiresBaseConversion')
-            ->will($this->returnValue(false))
-        ;
-
-        $converter
-            ->expects($this->atLeastOnce())
             ->method('convertValue')
             ->will($this->returnArgument(0))
         ;
@@ -602,12 +596,6 @@ final class WhereBuilderTest extends DbalTestCase
                     }
                 )
             )
-        ;
-
-        $converter
-            ->expects($this->atLeastOnce())
-            ->method('requiresBaseConversion')
-            ->will($this->returnValue(false))
         ;
 
         $whereBuilder->setConverter('customer_birthday', $converter);


### PR DESCRIPTION
None of the bundled convertors uses this method and it’s still possible to call this internally.
This simplifies the interface and makes the code more predictable.