### PR TITLE
Redesign the column mapping configuration

### DIFF
--- a/src/Extension/Conversion/AgeDateConversion.php
+++ b/src/Extension/Conversion/AgeDateConversion.php
@@ -44,7 +44,7 @@ class AgeDateConversion implements ConversionStrategyInterface, SqlFieldConversi
         }
 
         if ($value instanceof \DateTimeInterface) {
-            return $hints->field->getDbType()->getName() !== 'date' ? 2 : 3;
+            return $hints->field->dbType->getName() !== 'date' ? 2 : 3;
         }
 
         return 1;

--- a/src/Extension/Conversion/MoneyValueConversion.php
+++ b/src/Extension/Conversion/MoneyValueConversion.php
@@ -64,7 +64,7 @@ class MoneyValueConversion implements SqlValueConversionInterface, SqlFieldConve
      */
     public function convertSqlField(string $column, array $options, ConversionHints $hints): string
     {
-        if (DbType::DECIMAL === $hints->field->getDbType()->getName()) {
+        if (DbType::DECIMAL === $hints->field->dbType->getName()) {
             return $column;
         }
 

--- a/src/QueryPlatformInterface.php
+++ b/src/QueryPlatformInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Doctrine\Dbal;
 
+use Rollerworks\Component\Search\Doctrine\Dbal\Query\QueryField;
 use Rollerworks\Component\Search\Value\PatternMatch;
 
 interface QueryPlatformInterface
@@ -20,25 +21,24 @@ interface QueryPlatformInterface
     /**
      * Returns the correct column (with SQLField conversions applied).
      *
-     * @param string $fieldName
-     * @param int    $strategy
-     * @param string $column
+     * @param QueryField $mappingConfig
+     * @param int        $strategy
      *
      * @return string
      */
-    public function getFieldColumn(string $fieldName, int $strategy = 0, string $column = ''): string;
+    public function getFieldColumn(QueryField $mappingConfig, int $strategy = 0): string;
 
     /**
      * Returns either the converted value.
      *
-     * @param mixed  $value
-     * @param string $fieldName
-     * @param string $column
-     * @param int    $strategy
+     * @param mixed      $value
+     * @param QueryField $mappingConfig
+     * @param string     $column
+     * @param int        $strategy
      *
      * @return string|int
      */
-    public function getValueAsSql($value, string $fieldName, string $column, int $strategy = 0);
+    public function getValueAsSql($value, QueryField $mappingConfig, string $column, int $strategy = 0);
 
     /**
      * Returns the formatted PatternMatch query.
@@ -51,14 +51,14 @@ interface QueryPlatformInterface
     public function getPatternMatcher(PatternMatch $patternMatch, string $column): string;
 
     /**
-     * @param mixed  $value
-     * @param string $fieldName
-     * @param string $column
-     * @param int    $strategy
+     * @param mixed      $value
+     * @param QueryField $mappingConfig
+     * @param string     $column
+     * @param int        $strategy
      *
      * @return string|int
      */
-    public function convertSqlValue($value, string $fieldName, string $column, int $strategy = 0);
+    public function convertSqlValue($value, QueryField $mappingConfig, string $column, int $strategy = 0);
 
     /**
      * Returns the SQL for the match (regexp).

--- a/src/WhereBuilder.php
+++ b/src/WhereBuilder.php
@@ -28,10 +28,13 @@ use Rollerworks\Component\Search\SearchCondition;
  * This class provides the functionality for creating an SQL WHERE-clause
  * based on the provided SearchCondition.
  *
+ * Note that only fields that have been configured with `setField()`
+ * will be actually used in the generated query.
+ *
  * Keep the following in mind when using conversions.
  *
- *  * Conversions are performed per field and must be stateless,
- *    they receive the type and connection information for the conversion process.
+ *  * Conversions are performed per search field and must be stateless,
+ *    they receive the db-type and connection information for the conversion process.
  *  * Conversions apply at the SQL level, meaning they must be platform specific.
  *  * SQL conversions must be properly escaped to prevent SQL injections.
  *
@@ -50,14 +53,9 @@ class WhereBuilder implements WhereBuilderInterface
     private $fieldSet;
 
     /**
-     * @var ValueConversionInterface[]|SqlValueConversionInterface[]|ConversionStrategyInterface[]
+     * @var array
      */
-    private $valueConversions = [];
-
-    /**
-     * @var SqlFieldConversionInterface[]
-     */
-    private $fieldConversions = [];
+    private $converters = [];
 
     /**
      * @var string
@@ -68,11 +66,6 @@ class WhereBuilder implements WhereBuilderInterface
      * @var array[]
      */
     private $fields = [];
-
-    /**
-     * @var array[]
-     */
-    private $combinedFields = [];
 
     /**
      * @var Connection
@@ -95,19 +88,30 @@ class WhereBuilder implements WhereBuilderInterface
     }
 
     /**
-     * Set Field configuration for the query-generation.
+     * Set the search field to database table-column mapping configuration.
      *
-     * @param string             $fieldName Name of the Search-field
-     * @param string             $column    DB column-name
-     * @param string|MappingType $type      DB mapping-type
-     * @param string             $alias     alias to use with the column
+     * To map a field to more then one column use `field-name#mapping-name`
+     * for the $fieldName argument. The `field-name` is the field name as registered
+     * in the FieldSet, `mapping-name` allows to configure then one mapping for a field.
      *
-     * @throws UnknownFieldException  When the field is not registered in the fieldset
-     * @throws BadMethodCallException When the where-clause is already generated
+     * Caution: A field can only have multiple mappings or one, omitting `#` will remove
+     * any existing mappings for that field. Registering the field without `#` first and then
+     * setting multiple mappings for that field will reset the single mapping.
      *
-     * @return self
+     * Tip: The `mapping-name` doesn't have to be same as $column, but using a clear name
+     * will help with trouble shooting.
+     *
+     * @param string $fieldName Name of the search field as registered
+     *                          in the FieldSet or `field-name#mapping-name`
+     *                          to configure a secondary mapping
+     * @param string $column    Database table column-name
+     * @param string $alias     Table alias as used in the query "u" for
+     *                          `FROM users AS u`
+     * @param string $type      Doctrine DBAL registered type
+     *
+     * @return WhereBuilder When the field is not registered in the fieldset
      */
-    public function setField(string $fieldName, string $column, $type = 'string', string $alias = null)
+    public function setField(string $fieldName, string $column, string $alias = null, string $type = 'string')
     {
         if ($this->whereClause) {
             throw new BadMethodCallException(
@@ -115,64 +119,20 @@ class WhereBuilder implements WhereBuilderInterface
             );
         }
 
-        $this->fields[$fieldName] = [];
-        $this->fields[$fieldName]['field'] = $this->fieldSet->get($fieldName);
-        $this->fields[$fieldName]['db_type'] = is_object($type) ? $type : MappingType::getType($type);
-        $this->fields[$fieldName]['alias'] = $alias;
-        $this->fields[$fieldName]['column'] = $column;
-    }
+        $mappingIdx = null;
 
-    /**
-     * Set a CombinedField configuration for the query-generation.
-     *
-     * The $mappings expects an array with one or more mappings or null to unset this field.
-     * Each mapping must have a `column`, all other keys are optional.
-     *
-     * @param string     $fieldName Name of the Search-field
-     * @param array|null $mappings  ['mapping-name' => ['column' => '...', 'type' => 'string', 'alias' => null], ...]
-     *
-     * @throws UnknownFieldException  When the field is not registered in the fieldset
-     * @throws BadMethodCallException When the where-clause is already generated
-     *
-     * @return self
-     */
-    public function setCombinedField(string $fieldName, array $mappings = null)
-    {
-        if ($this->whereClause) {
-            throw new BadMethodCallException(
-                'WhereBuilder configuration methods cannot be accessed anymore once the where-clause is generated.'
-            );
+        if (false !== strpos($fieldName, '#')) {
+            list($fieldName, $mappingIdx) = explode('#', $fieldName, 2);
+            unset($this->fields[$fieldName][null]);
+        } else {
+            $this->fields[$fieldName] = [];
         }
 
-        $fieldConfig = $this->fieldSet->get($fieldName);
-
-        if (null === $mappings) {
-            unset($this->combinedFields[$fieldName]);
-
-            return $this;
-        }
-
-        foreach ($mappings as $n => $mapping) {
-            if (!isset($mapping['column'])) {
-                throw new \InvalidArgumentException(
-                    sprintf('Combined search field "%s" is missing "column" at index "%s".', $fieldName, $n)
-                );
-            }
-
-            if (!isset($mapping['type'])) {
-                $mapping['type'] = 'string';
-            }
-
-            $this->combinedFields[$fieldName][$n] = [];
-            $this->combinedFields[$fieldName][$n]['field'] = $fieldConfig;
-            $this->combinedFields[$fieldName][$n]['alias'] = isset($mapping['alias']) ? $mapping['alias'] : null;
-            $this->combinedFields[$fieldName][$n]['column'] = $mapping['column'];
-            $this->combinedFields[$fieldName][$n]['db_type'] = is_object($mapping['type']) ? $mapping['type'] : MappingType::getType($mapping['type']);
-        }
-
-        unset($this->fields[$fieldName]);
-
-        return $this;
+        $this->fields[$fieldName][$mappingIdx] = [];
+        $this->fields[$fieldName][$mappingIdx]['field'] = $this->fieldSet->get($fieldName);
+        $this->fields[$fieldName][$mappingIdx]['db_type'] = MappingType::getType($type);
+        $this->fields[$fieldName][$mappingIdx]['alias'] = $alias;
+        $this->fields[$fieldName][$mappingIdx]['column'] = $column;
     }
 
     /**
@@ -198,13 +158,7 @@ class WhereBuilder implements WhereBuilderInterface
             throw new UnknownFieldException($fieldName);
         }
 
-        if ($converter instanceof ValueConversionInterface) {
-            $this->valueConversions[$fieldName] = $converter;
-        }
-
-        if ($converter instanceof SqlFieldConversionInterface) {
-            $this->fieldConversions[$fieldName] = $converter;
-        }
+        $this->converters[$fieldName] = $converter;
 
         return $this;
     }
@@ -251,55 +205,21 @@ class WhereBuilder implements WhereBuilderInterface
         return $this->searchCondition;
     }
 
-    /**
-     * @return ConversionStrategyInterface[]|SqlValueConversionInterface[]|ValueConversionInterface[]
-     */
-    public function getValueConversions()
-    {
-        return $this->valueConversions;
-    }
-
-    /**
-     * @return SqlFieldConversionInterface[]|ConversionStrategyInterface[]
-     */
-    public function getFieldConversions()
-    {
-        return $this->fieldConversions;
-    }
-
     private function processFields()
     {
         $fields = [];
 
-        foreach ($this->fields as $fieldName => $field) {
-            $fields[$fieldName] = new QueryField(
-                $this->fieldSet->get($fieldName),
-                $field['db_type'],
-                $field['alias'],
-                $field['column'],
-                isset($this->fieldConversions[$fieldName]) ? $this->fieldConversions[$fieldName] : null,
-                isset($this->valueConversions[$fieldName]) ? $this->valueConversions[$fieldName] : null
-            );
-        }
-
-        foreach ($this->combinedFields as $fieldName => $subFieldsConfig) {
-            $subsFieldNames = [];
-
-            foreach ($subFieldsConfig as $n => $field) {
-                $fieldNameN = $fieldName.'#'.$n;
-
-                $subsFieldNames[] = $fieldNameN;
-                $fields[$fieldNameN] = new QueryField(
+        foreach ($this->fields as $fieldName => $fieldMappings) {
+            foreach ($fieldMappings as $n => $field) {
+                $fields[$fieldName][$n] = new QueryField(
+                    $fieldName.(null !== $n ? "#$n" : ''),
                     $field['field'],
                     $field['db_type'],
-                    $field['alias'],
                     $field['column'],
-                    isset($this->fieldConversions[$fieldName]) ? $this->fieldConversions[$fieldName] : null,
-                    isset($this->valueConversions[$fieldName]) ? $this->valueConversions[$fieldName] : null
+                    $field['alias'],
+                    $this->converters[$fieldName] ?? null
                 );
             }
-
-            $fields[$fieldName] = $subsFieldNames;
         }
 
         return $fields;

--- a/tests/DoctrineDbalFactoryTest.php
+++ b/tests/DoctrineDbalFactoryTest.php
@@ -63,8 +63,6 @@ class DoctrineDbalFactoryTest extends DbalTestCase
         $whereBuilder = $this->factory->createWhereBuilder($connection, $searchCondition);
 
         $this->assertInstanceOf(WhereBuilder::class, $whereBuilder);
-        $this->assertEquals(['invoice_label' => $conversion], $whereBuilder->getValueConversions());
-        $this->assertCount(0, $whereBuilder->getFieldConversions());
     }
 
     public function testCreateWhereBuilderWithLazyConversionSetting()
@@ -94,8 +92,6 @@ class DoctrineDbalFactoryTest extends DbalTestCase
         $whereBuilder = $this->factory->createWhereBuilder($connection, $searchCondition);
 
         $this->assertInstanceOf(WhereBuilder::class, $whereBuilder);
-        $this->assertEquals(['invoice_label' => $conversion], $whereBuilder->getValueConversions());
-        $this->assertCount(0, $whereBuilder->getFieldConversions());
     }
 
     public function testCreateCacheWhereBuilder()

--- a/tests/Functional/Extension/Conversion/AgeConversionTest.php
+++ b/tests/Functional/Extension/Conversion/AgeConversionTest.php
@@ -55,7 +55,7 @@ final class AgeConversionTest extends FunctionalDbalTestCase
 
     protected function configureWhereBuilder(WhereBuilder $whereBuilder)
     {
-        $whereBuilder->setField('birthday', 'birthday', 'date', 'u');
+        $whereBuilder->setField('birthday', 'birthday', 'u', 'date');
     }
 
     protected function getFieldSet(bool $build = true)

--- a/tests/Functional/Extension/Conversion/ChildCountTypeTest.php
+++ b/tests/Functional/Extension/Conversion/ChildCountTypeTest.php
@@ -65,7 +65,7 @@ final class ChildCountTypeTest extends FunctionalDbalTestCase
 
     protected function configureWhereBuilder(WhereBuilder $whereBuilder)
     {
-        $whereBuilder->setField('contact_count', 'id', 'integer', 'u');
+        $whereBuilder->setField('contact_count', 'id', 'u', 'integer');
     }
 
     protected function getFieldSet(bool $build = true)

--- a/tests/Functional/Extension/Conversion/MoneyValueConversionTest.php
+++ b/tests/Functional/Extension/Conversion/MoneyValueConversionTest.php
@@ -60,8 +60,8 @@ final class MoneyValueConversionTest extends FunctionalDbalTestCase
 
     protected function configureWhereBuilder(WhereBuilder $whereBuilder)
     {
-        $whereBuilder->setField('price', 'price', 'string', 'p');
-        $whereBuilder->setField('total', 'total', 'decimal', 'p');
+        $whereBuilder->setField('price', 'price', 'p', 'string');
+        $whereBuilder->setField('total', 'total', 'p', 'decimal');
     }
 
     protected function getFieldSet(bool $build = true)

--- a/tests/Functional/WhereBuilderResultsTest.php
+++ b/tests/Functional/WhereBuilderResultsTest.php
@@ -191,28 +191,27 @@ SQL;
     protected function configureWhereBuilder(WhereBuilder $whereBuilder)
     {
         // Customer (by invoice relation)
-        $whereBuilder->setField('customer-first-name', 'first_name', 'string', 'c');
-        $whereBuilder->setField('customer-last-name', 'last_name', 'string', 'c');
-        $whereBuilder->setField('customer-birthday', 'birthday', 'date', 'c');
-        $whereBuilder->setField('customer-regdate', 'regdate', 'date', 'c');
-        $whereBuilder->setCombinedField('customer-name', [
-            ['column' => 'first_name', 'type' => 'string', 'alias' => 'c'],
-            ['column' => 'last_name', 'type' => 'string', 'alias' => 'c'],
-        ]);
+        $whereBuilder->setField('customer-first-name', 'first_name', 'c', 'string');
+        $whereBuilder->setField('customer-last-name', 'last_name', 'c', 'string');
+        $whereBuilder->setField('customer-birthday', 'birthday', 'c', 'date');
+        $whereBuilder->setField('customer-regdate', 'regdate', 'c', 'date');
+
+        $whereBuilder->setField('customer-name#first_name', 'first_name', 'c', 'string');
+        $whereBuilder->setField('customer-name#last_name', 'last_name', 'c', 'string');
 
         // Invoice
-        $whereBuilder->setField('id', 'id', 'integer', 'i');
-        $whereBuilder->setField('customer', 'customer', 'integer', 'i');
-        $whereBuilder->setField('label', 'label', 'string', 'i');
-        $whereBuilder->setField('pub-date', 'pub_date', 'date', 'i');
-        $whereBuilder->setField('status', 'status', 'integer', 'i');
-        $whereBuilder->setField('total', 'price_total', 'decimal', 'i');
+        $whereBuilder->setField('id', 'id', 'i', 'integer');
+        $whereBuilder->setField('customer', 'customer', 'i', 'integer');
+        $whereBuilder->setField('label', 'label', 'i', 'string');
+        $whereBuilder->setField('pub-date', 'pub_date', 'i', 'date');
+        $whereBuilder->setField('status', 'status', 'i', 'integer');
+        $whereBuilder->setField('total', 'price_total', 'i', 'decimal');
 
         // Invoice Details
-        $whereBuilder->setField('row-label', 'label', 'string', 'ir');
-        $whereBuilder->setField('row-quantity', 'quantity', 'integer', 'ir');
-        $whereBuilder->setField('row-price', 'price', 'decimal', 'ir');
-        $whereBuilder->setField('row-total', 'total', 'decimal', 'ir');
+        $whereBuilder->setField('row-label', 'label', 'ir', 'string');
+        $whereBuilder->setField('row-quantity', 'quantity', 'ir', 'integer');
+        $whereBuilder->setField('row-price', 'price', 'ir', 'decimal');
+        $whereBuilder->setField('row-total', 'total', 'ir', 'decimal');
     }
 
     protected function getFieldSet(bool $build = true)

--- a/tests/Functional/WhereBuilderTest.php
+++ b/tests/Functional/WhereBuilderTest.php
@@ -63,11 +63,11 @@ final class WhereBuilderTest extends FunctionalDbalTestCase
      */
     protected function configureWhereBuilder(WhereBuilder $whereBuilder)
     {
-        $whereBuilder->setField('customer', 'customer', 'integer', 'i');
-        $whereBuilder->setField('customer_name', 'name', 'string', 'c');
-        $whereBuilder->setField('customer_birthday', 'birthday', 'string', 'c'); // don't use date as this breaks the binding
-        $whereBuilder->setField('status', 'status', 'integer', 'i');
-        $whereBuilder->setField('label', 'label', 'string', 'i');
+        $whereBuilder->setField('customer', 'customer', 'i', 'integer');
+        $whereBuilder->setField('customer_name', 'name', 'c', 'string');
+        $whereBuilder->setField('customer_birthday', 'birthday', 'c', 'string'); // don't use date as this breaks the binding
+        $whereBuilder->setField('status', 'status', 'i', 'integer');
+        $whereBuilder->setField('label', 'label', 'i', 'string');
     }
 
     public function testSimpleQuery()

--- a/tests/WhereBuilderTest.php
+++ b/tests/WhereBuilderTest.php
@@ -36,11 +36,11 @@ final class WhereBuilderTest extends DbalTestCase
             $condition
         );
 
-        $whereBuilder->setField('customer', 'customer', 'integer', 'I');
-        $whereBuilder->setField('customer_name', 'name', 'string', 'C');
-        $whereBuilder->setField('customer_birthday', 'birthday', 'date', 'C');
-        $whereBuilder->setField('status', 'status', 'integer', 'I');
-        $whereBuilder->setField('label', 'label', 'string', 'I');
+        $whereBuilder->setField('customer', 'customer', 'I', 'integer');
+        $whereBuilder->setField('customer_name', 'name', 'C', 'string');
+        $whereBuilder->setField('customer_birthday', 'birthday', 'C', 'date');
+        $whereBuilder->setField('status', 'status', 'I', 'integer');
+        $whereBuilder->setField('label', 'label', 'I', 'string');
 
         return $whereBuilder;
     }
@@ -115,7 +115,8 @@ final class WhereBuilderTest extends DbalTestCase
         ->getSearchCondition();
 
         $whereBuilder = $this->getWhereBuilder($condition);
-        $whereBuilder->setCombinedField('customer', [['column' => 'id'], ['column' => 'number2']]);
+        $whereBuilder->setField('customer#1', 'id');
+        $whereBuilder->setField('customer#2', 'number2');
 
         $this->assertEquals('(((id IN(2, 5) OR number2 IN(2, 5))))', $whereBuilder->getWhereClause());
     }
@@ -130,7 +131,8 @@ final class WhereBuilderTest extends DbalTestCase
         ->getSearchCondition();
 
         $whereBuilder = $this->getWhereBuilder($condition);
-        $whereBuilder->setCombinedField('customer', [['column' => 'id'], ['column' => 'number2', 'alias' => 'C']]);
+        $whereBuilder->setField('customer#1', 'id');
+        $whereBuilder->setField('customer#2', 'number2', 'C', 'string');
 
         $this->assertEquals('(((id IN(2, 5) OR C.number2 IN(2, 5))))', $whereBuilder->getWhereClause());
     }
@@ -452,7 +454,6 @@ final class WhereBuilderTest extends DbalTestCase
             ->method('convertSqlField')
             ->will($this->returnCallback(function ($column, array $options, ConversionHints $hints) use ($test, $passedOptions) {
                 $test->assertEquals($options, $options);
-                $test->assertEquals('I', $hints->field->getAlias());
                 $test->assertEquals('I.customer', $hints->column);
 
                 return "CAST($column AS customer_type)";
@@ -624,7 +625,7 @@ final class WhereBuilderTest extends DbalTestCase
         $options = $fieldSet->get('customer_birthday')->getOptions();
 
         $whereBuilder = $this->getWhereBuilder($condition);
-        $whereBuilder->setField('customer_birthday', 'birthday', 'string', 'C');
+        $whereBuilder->setField('customer_birthday', 'birthday', 'C', 'string');
 
         $test = $this;
 


### PR DESCRIPTION
The column mapping system is completely redesigned for speed, a good developer experience
and less complexity. A number of unused methods were removed.

## WhereBuilder

* setField() now allows to set the mappings for multiple columns more cleanly
* setField() no longer accepts types as object (string only)
* setField() arguments changed to: $fieldName, $column, $alias, $type
* getFieldConversions() and getValueConversions() have been removed as they are not actually used anywhere
* Updated and clarified php descriptions

## QueryField

* This class now final
* Properties are now public (READ-ONLY) for better performance
* All getter methods have been removed
* The column property now includes the table alias (if any),
   use tableColumn to get actual column name with alias

## QueryGenerator / QueryPlatformInterface

* Internal methods now expect the QueryField rather then the fieldName
* The provided fields must be a nested array now `[field-name][mapping-name] => QueryField`