### PR TITLE
Refactor WhereBuilder (caching) and mapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "php": "^7.1",
         "rollerworks/search": "^2.0@dev",
-        "doctrine/dbal": "^2.5.5"
+        "doctrine/dbal": "^2.5.5",
+        "psr/simple-cache": "^1.0.0"
     },
     "require-dev": {
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",

--- a/src/Extension/Type/FieldTypeExtension.php
+++ b/src/Extension/Type/FieldTypeExtension.php
@@ -15,8 +15,8 @@ namespace Rollerworks\Component\Search\Extension\Doctrine\Dbal\Type;
 
 use Rollerworks\Component\Search\Doctrine\Dbal\ColumnConversion;
 use Rollerworks\Component\Search\Doctrine\Dbal\ValueConversion;
+use Rollerworks\Component\Search\Extension\Core\Type\SearchFieldType;
 use Rollerworks\Component\Search\Field\AbstractFieldTypeExtension;
-use Rollerworks\Component\Search\Field\FieldType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -51,6 +51,6 @@ class FieldTypeExtension extends AbstractFieldTypeExtension
      */
     public function getExtendedType(): string
     {
-        return FieldType::class;
+        return SearchFieldType::class;
     }
 }

--- a/src/Query/QueryField.php
+++ b/src/Query/QueryField.php
@@ -52,7 +52,7 @@ final class QueryField
     /**
      * @var ColumnConversion|StrategySupportedConversion|null
      */
-    public $fieldConversion;
+    public $columnConversion;
 
     /**
      * @var ValueConversion|StrategySupportedConversion|null
@@ -97,7 +97,7 @@ final class QueryField
         $converter = $converter ?? $fieldConfig->getOption('doctrine_dbal_conversion');
 
         if ($converter instanceof ColumnConversion) {
-            $this->fieldConversion = $converter;
+            $this->columnConversion = $converter;
         }
 
         if ($converter instanceof ValueConversion) {

--- a/src/Query/QueryGenerator.php
+++ b/src/Query/QueryGenerator.php
@@ -292,8 +292,8 @@ final class QueryGenerator
             );
         }
 
-        if ($mappingConfig->fieldConversion instanceof StrategySupportedConversion) {
-            return $mappingConfig->fieldConversion->getConversionStrategy(
+        if ($mappingConfig->columnConversion instanceof StrategySupportedConversion) {
+            return $mappingConfig->columnConversion->getConversionStrategy(
                 $value,
                 $mappingConfig->fieldConfig->getOptions(),
                 $this->getConversionHints($mappingConfig)

--- a/src/QueryPlatform/AbstractQueryPlatform.php
+++ b/src/QueryPlatform/AbstractQueryPlatform.php
@@ -31,11 +31,6 @@ use Rollerworks\Component\Search\Value\PatternMatch;
 abstract class AbstractQueryPlatform implements QueryPlatformInterface
 {
     /**
-     * @var QueryField[]
-     */
-    protected $fields = [];
-
-    /**
      * @var array[]
      */
     protected $fieldsMappingCache = [];
@@ -48,13 +43,11 @@ abstract class AbstractQueryPlatform implements QueryPlatformInterface
     /**
      * Constructor.
      *
-     * @param Connection   $connection
-     * @param QueryField[] $fields
+     * @param Connection $connection
      */
-    public function __construct(Connection $connection, array $fields)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->fields = $fields;
     }
 
     /**

--- a/src/QueryPlatform/AbstractQueryPlatform.php
+++ b/src/QueryPlatform/AbstractQueryPlatform.php
@@ -86,8 +86,8 @@ abstract class AbstractQueryPlatform implements QueryPlatformInterface
         $column = $mappingConfig->column;
         $this->fieldsMappingCache[$mappingName][$strategy] = $column;
 
-        if ($mappingConfig->fieldConversion instanceof ColumnConversion) {
-            $this->fieldsMappingCache[$mappingName][$strategy] = $mappingConfig->fieldConversion->convertColumn(
+        if ($mappingConfig->columnConversion instanceof ColumnConversion) {
+            $this->fieldsMappingCache[$mappingName][$strategy] = $mappingConfig->columnConversion->convertColumn(
                 $column,
                 $mappingConfig->fieldConfig->getOptions(),
                 $this->getConversionHints($mappingConfig, $column, $strategy)

--- a/src/WhereBuilder.php
+++ b/src/WhereBuilder.php
@@ -18,7 +18,6 @@ use Doctrine\DBAL\Types\Type as MappingType;
 use Rollerworks\Component\Search\Doctrine\Dbal\Query\QueryField;
 use Rollerworks\Component\Search\Doctrine\Dbal\Query\QueryGenerator;
 use Rollerworks\Component\Search\Exception\BadMethodCallException;
-use Rollerworks\Component\Search\Exception\UnknownFieldException;
 use Rollerworks\Component\Search\FieldSet;
 use Rollerworks\Component\Search\SearchCondition;
 
@@ -40,7 +39,7 @@ use Rollerworks\Component\Search\SearchCondition;
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class WhereBuilder implements WhereBuilderInterface
+final class WhereBuilder implements WhereBuilderInterface
 {
     /**
      * @var SearchCondition
@@ -51,11 +50,6 @@ class WhereBuilder implements WhereBuilderInterface
      * @var FieldSet
      */
     private $fieldSet;
-
-    /**
-     * @var array
-     */
-    private $converters = [];
 
     /**
      * @var string
@@ -77,8 +71,6 @@ class WhereBuilder implements WhereBuilderInterface
      *
      * @param Connection      $connection      Doctrine DBAL Connection object
      * @param SearchCondition $searchCondition SearchCondition object
-     *
-     * @throws BadMethodCallException When SearchCondition contains errors
      */
     public function __construct(Connection $connection, SearchCondition $searchCondition)
     {
@@ -88,28 +80,7 @@ class WhereBuilder implements WhereBuilderInterface
     }
 
     /**
-     * Set the search field to database table-column mapping configuration.
-     *
-     * To map a field to more then one column use `field-name#mapping-name`
-     * for the $fieldName argument. The `field-name` is the field name as registered
-     * in the FieldSet, `mapping-name` allows to configure then one mapping for a field.
-     *
-     * Caution: A field can only have multiple mappings or one, omitting `#` will remove
-     * any existing mappings for that field. Registering the field without `#` first and then
-     * setting multiple mappings for that field will reset the single mapping.
-     *
-     * Tip: The `mapping-name` doesn't have to be same as $column, but using a clear name
-     * will help with trouble shooting.
-     *
-     * @param string $fieldName Name of the search field as registered
-     *                          in the FieldSet or `field-name#mapping-name`
-     *                          to configure a secondary mapping
-     * @param string $column    Database table column-name
-     * @param string $alias     Table alias as used in the query "u" for
-     *                          `FROM users AS u`
-     * @param string $type      Doctrine DBAL registered type
-     *
-     * @return WhereBuilder When the field is not registered in the fieldset
+     * {@inheritdoc}
      */
     public function setField(string $fieldName, string $column, string $alias = null, string $type = 'string')
     {
@@ -128,66 +99,24 @@ class WhereBuilder implements WhereBuilderInterface
             $this->fields[$fieldName] = [];
         }
 
-        $this->fields[$fieldName][$mappingIdx] = [];
-        $this->fields[$fieldName][$mappingIdx]['field'] = $this->fieldSet->get($fieldName);
-        $this->fields[$fieldName][$mappingIdx]['db_type'] = MappingType::getType($type);
-        $this->fields[$fieldName][$mappingIdx]['alias'] = $alias;
-        $this->fields[$fieldName][$mappingIdx]['column'] = $column;
+        $this->fields[$fieldName][$mappingIdx] = new QueryField(
+            $fieldName.(null !== $mappingIdx ? "#$mappingIdx" : ''),
+            $this->fieldSet->get($fieldName),
+            MappingType::getType($type),
+            $column,
+            $alias
+        );
     }
 
     /**
-     * Set the converters for a field.
-     *
-     * Setting is done per type (field or value), any existing conversions are overwritten.
-     *
-     * @param string                           $fieldName
-     * @param ValueConversion|ColumnConversion $converter
-     *
-     * @throws UnknownFieldException  When the field is not registered in the fieldset
-     * @throws BadMethodCallException When the where-clause is already generated
-     *
-     * @return self
-     */
-    public function setConverter(string $fieldName, $converter)
-    {
-        if ($this->whereClause) {
-            throw new BadMethodCallException('WhereBuilder configuration methods cannot be accessed anymore once the where-clause is generated.');
-        }
-
-        if (!$this->fieldSet->has($fieldName)) {
-            throw new UnknownFieldException($fieldName);
-        }
-
-        $this->converters[$fieldName] = $converter;
-
-        return $this;
-    }
-
-    /**
-     * Returns the generated where-clause.
-     *
-     * The Where-clause is wrapped inside a group so it
-     * can be safely used with other conditions.
-     *
-     * Values are embedded with in the Query.
-     *
-     * @param string $prependQuery Prepends this string to the where-clause
-     *                             (" WHERE " or " AND " for example)
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getWhereClause(string $prependQuery = ''): string
     {
         if (null === $this->whereClause) {
-            $fields = $this->processFields();
-
-            $queryGenerator = new QueryGenerator(
-                $this->connection, $this->getQueryPlatform($fields), $fields
-            );
-
-            $this->whereClause = $queryGenerator->getGroupQuery(
-                $this->searchCondition->getValuesGroup()
-            );
+            $this->whereClause = (new QueryGenerator(
+                $this->connection, $this->getQueryPlatform(), $this->fields
+            ))->getGroupQuery($this->searchCondition->getValuesGroup());
         }
 
         if ('' !== $this->whereClause) {
@@ -198,40 +127,28 @@ class WhereBuilder implements WhereBuilderInterface
     }
 
     /**
-     * @return SearchCondition
+     * {@inheritdoc}
+     */
+    public function getFieldsMapping(): array
+    {
+        return $this->fields;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function getSearchCondition(): SearchCondition
     {
         return $this->searchCondition;
     }
 
-    private function processFields()
-    {
-        $fields = [];
-
-        foreach ($this->fields as $fieldName => $fieldMappings) {
-            foreach ($fieldMappings as $n => $field) {
-                $fields[$fieldName][$n] = new QueryField(
-                    $fieldName.(null !== $n ? "#$n" : ''),
-                    $field['field'],
-                    $field['db_type'],
-                    $field['column'],
-                    $field['alias'],
-                    $this->converters[$fieldName] ?? null
-                );
-            }
-        }
-
-        return $fields;
-    }
-
-    private function getQueryPlatform(array $fields): QueryPlatformInterface
+    private function getQueryPlatform(): QueryPlatformInterface
     {
         $dbPlatform = ucfirst($this->connection->getDatabasePlatform()->getName());
         $platformClass = 'Rollerworks\\Component\\Search\\Doctrine\\Dbal\\QueryPlatform\\'.$dbPlatform.'QueryPlatform';
 
         if (class_exists($platformClass)) {
-            return new $platformClass($this->connection, $fields);
+            return new $platformClass($this->connection);
         }
 
         throw new \RuntimeException(sprintf('No supported class found for database-platform "%s".', $dbPlatform));

--- a/src/WhereBuilderInterface.php
+++ b/src/WhereBuilderInterface.php
@@ -13,9 +13,17 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Doctrine\Dbal;
 
+use Rollerworks\Component\Search\Exception\BadMethodCallException;
+use Rollerworks\Component\Search\Exception\UnknownFieldException;
 use Rollerworks\Component\Search\SearchCondition;
 
 /**
+ * A Doctrine DBAL WhereBuilder generates WHERE an SQL WHERE-clause
+ * based on the provided SearchCondition.
+ *
+ * This interface is provided for type hinting it should not
+ * be implemented in external code.
+ *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
 interface WhereBuilderInterface
@@ -23,12 +31,56 @@ interface WhereBuilderInterface
     /**
      * Returns the generated where-clause.
      *
+     * @param string $prependQuery Prepend before the generated WHERE clause
+     *                             Eg. " WHERE " or " AND ", ignored when WHERE
+     *                             clause is empty.
+     *
      * @return string
      */
-    public function getWhereClause(): string;
+    public function getWhereClause(string $prependQuery = ''): string;
 
     /**
+     * Set the search field to database table-column mapping configuration.
+     *
+     * To map a field to more then one column use `field-name#mapping-name`
+     * for the $fieldName argument. The `field-name` is the field name as registered
+     * in the FieldSet, `mapping-name` allows to configure a (secondary) mapping for a field.
+     *
+     * Caution: A field can only have multiple mappings or one, omitting `#` will remove
+     * any existing mappings for that field. Registering the field without `#` first and then
+     * setting multiple mappings for that field will reset the single mapping.
+     *
+     * Tip: The `mapping-name` doesn't have to be same as $column, but using a clear name
+     * will help with trouble shooting.
+     *
+     * @param string $fieldName Name of the search field as registered in the FieldSet or
+     *                          `field-name#mapping-name` to configure a secondary mapping
+     * @param string $column    Database table column-name
+     * @param string $alias     Table alias as used in the query "u" for `FROM users AS u`
+     * @param string $type      Doctrine DBAL supported type, eg. string (not text)
+     *
+     * @throws UnknownFieldException  When the field is not registered in the fieldset
+     * @throws BadMethodCallException When the where-clause is already generated
+     *
+     * @return $this
+     */
+    public function setField(string $fieldName, string $column, string $alias = null, string $type = 'string');
+
+    /**
+     * Returns the assigned SearchCondition.
+     *
+     * @internal
+     *
      * @return SearchCondition
      */
     public function getSearchCondition(): SearchCondition;
+
+    /**
+     * Returns the configured field to columns mapping.
+     *
+     * @internal
+     *
+     * @return array[] [field-name][mapping-name] => QueryField
+     */
+    public function getFieldsMapping(): array;
 }

--- a/tests/DbalTestCase.php
+++ b/tests/DbalTestCase.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal;
 
-use Doctrine\Common\Cache\Cache;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver as PDOSqlite;
+use Psr\SimpleCache\CacheInterface;
 use Rollerworks\Component\Search\Doctrine\Dbal\DoctrineDbalFactory;
 use Rollerworks\Component\Search\Extension\Core\Type\DateType;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
@@ -49,7 +49,7 @@ abstract class DbalTestCase extends SearchIntegrationTestCase
 
     protected function getDbalFactory()
     {
-        $cacheDriver = $this->getMockBuilder(Cache::class)->getMock();
+        $cacheDriver = $this->getMockBuilder(CacheInterface::class)->getMock();
 
         return new DoctrineDbalFactory($cacheDriver);
     }

--- a/tests/DoctrineDbalFactoryTest.php
+++ b/tests/DoctrineDbalFactoryTest.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal;
 
-use Doctrine\Common\Cache\Cache;
+use Psr\SimpleCache\CacheInterface as Cache;
 use Rollerworks\Component\Search\Doctrine\Dbal\CacheWhereBuilder;
 use Rollerworks\Component\Search\Doctrine\Dbal\DoctrineDbalFactory;
-use Rollerworks\Component\Search\Doctrine\Dbal\ValueConversion;
 use Rollerworks\Component\Search\Doctrine\Dbal\WhereBuilder;
-use Rollerworks\Component\Search\Field\FieldConfig;
 use Rollerworks\Component\Search\GenericFieldSet;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Value\ValuesGroup;
@@ -37,61 +35,7 @@ class DoctrineDbalFactoryTest extends DbalTestCase
 
         $whereBuilder = $this->factory->createWhereBuilder($connection, $searchCondition);
 
-        $this->assertInstanceOf(WhereBuilder::class, $whereBuilder);
-    }
-
-    public function testCreateWhereBuilderWithConversionSetting()
-    {
-        $conversion = $this->createMock(ValueConversion::class);
-
-        $fieldLabel = $this->getMockBuilder(FieldConfig::class)->getMock();
-        $fieldLabel->expects($this->once())->method('hasOption')->with('doctrine_dbal_conversion')->will($this->returnValue(true));
-        $fieldLabel->expects($this->once())->method('getOption')->with('doctrine_dbal_conversion')->will($this->returnValue($conversion));
-
-        $fieldCustomer = $this->getMockBuilder(FieldConfig::class)->getMock();
-        $fieldCustomer->expects($this->once())->method('hasOption')->with('doctrine_dbal_conversion')->will($this->returnValue(false));
-        $fieldCustomer->expects($this->never())->method('getOption');
-
-        $fieldSet = new GenericFieldSet(
-            ['invoice_label' => $fieldLabel, 'invoice_customer' => $fieldCustomer],
-            'invoice'
-        );
-
-        $connection = $this->getConnectionMock();
-        $searchCondition = new SearchCondition($fieldSet, new ValuesGroup());
-
-        $whereBuilder = $this->factory->createWhereBuilder($connection, $searchCondition);
-
-        $this->assertInstanceOf(WhereBuilder::class, $whereBuilder);
-    }
-
-    public function testCreateWhereBuilderWithLazyConversionSetting()
-    {
-        $test = $this;
-        $conversion = $test->getMockBuilder(ValueConversion::class)->getMock();
-        $lazyConversion = function () use ($conversion) {
-            return $conversion;
-        };
-
-        $fieldLabel = $this->getMockBuilder(FieldConfig::class)->getMock();
-        $fieldLabel->expects($this->once())->method('hasOption')->with('doctrine_dbal_conversion')->will($this->returnValue(true));
-        $fieldLabel->expects($this->once())->method('getOption')->with('doctrine_dbal_conversion')->will($this->returnValue($lazyConversion));
-
-        $fieldCustomer = $this->getMockBuilder(FieldConfig::class)->getMock();
-        $fieldCustomer->expects($this->once())->method('hasOption')->with('doctrine_dbal_conversion')->will($this->returnValue(false));
-        $fieldCustomer->expects($this->never())->method('getOption');
-
-        $fieldSet = new GenericFieldSet(
-            ['invoice_label' => $fieldLabel, 'invoice_customer' => $fieldCustomer],
-            'invoice'
-        );
-
-        $connection = $this->getConnectionMock();
-        $searchCondition = new SearchCondition($fieldSet, new ValuesGroup());
-
-        $whereBuilder = $this->factory->createWhereBuilder($connection, $searchCondition);
-
-        $this->assertInstanceOf(WhereBuilder::class, $whereBuilder);
+        self::assertSame($searchCondition, $whereBuilder->getSearchCondition());
     }
 
     public function testCreateCacheWhereBuilder()

--- a/tests/Functional/Extension/Conversion/AgeConversionTest.php
+++ b/tests/Functional/Extension/Conversion/AgeConversionTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal\Functional\Extension\Conversion;
 
 use Doctrine\DBAL\Schema\Schema as DbSchema;
-use Rollerworks\Component\Search\Doctrine\Dbal\WhereBuilder;
+use Rollerworks\Component\Search\Doctrine\Dbal\WhereBuilderInterface;
 use Rollerworks\Component\Search\Extension\Core\Type\BirthdayType;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\SearchConditionBuilder;
@@ -53,7 +53,7 @@ final class AgeConversionTest extends FunctionalDbalTestCase
         return 'SELECT id FROM site_user AS u WHERE ';
     }
 
-    protected function configureWhereBuilder(WhereBuilder $whereBuilder)
+    protected function configureWhereBuilder(WhereBuilderInterface $whereBuilder)
     {
         $whereBuilder->setField('birthday', 'birthday', 'u', 'date');
     }

--- a/tests/Functional/Extension/Conversion/ChildCountTypeTest.php
+++ b/tests/Functional/Extension/Conversion/ChildCountTypeTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal\Functional\Extension\Conversion;
 
 use Doctrine\DBAL\Schema\Schema as DbSchema;
-use Rollerworks\Component\Search\Doctrine\Dbal\WhereBuilder;
+use Rollerworks\Component\Search\Doctrine\Dbal\WhereBuilderInterface;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Doctrine\Dbal\Type\ChildCountType;
 use Rollerworks\Component\Search\SearchConditionBuilder;
@@ -63,7 +63,7 @@ final class ChildCountTypeTest extends FunctionalDbalTestCase
         return 'SELECT id FROM site_user AS u WHERE ';
     }
 
-    protected function configureWhereBuilder(WhereBuilder $whereBuilder)
+    protected function configureWhereBuilder(WhereBuilderInterface $whereBuilder)
     {
         $whereBuilder->setField('contact_count', 'id', 'u', 'integer');
     }

--- a/tests/Functional/Extension/Conversion/MoneyValueConversionTest.php
+++ b/tests/Functional/Extension/Conversion/MoneyValueConversionTest.php
@@ -15,7 +15,7 @@ namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal\Functional\Extension\
 
 use Doctrine\DBAL\Schema\Schema as DbSchema;
 use Money\Money;
-use Rollerworks\Component\Search\Doctrine\Dbal\WhereBuilder;
+use Rollerworks\Component\Search\Doctrine\Dbal\WhereBuilderInterface;
 use Rollerworks\Component\Search\Extension\Core\Model\MoneyValue;
 use Rollerworks\Component\Search\Extension\Core\Type\IntegerType;
 use Rollerworks\Component\Search\Extension\Core\Type\MoneyType;
@@ -58,7 +58,7 @@ final class MoneyValueConversionTest extends FunctionalDbalTestCase
         return 'SELECT id FROM product AS p WHERE ';
     }
 
-    protected function configureWhereBuilder(WhereBuilder $whereBuilder)
+    protected function configureWhereBuilder(WhereBuilderInterface $whereBuilder)
     {
         $whereBuilder->setField('price', 'price', 'p', 'string');
         $whereBuilder->setField('total', 'total', 'p', 'decimal');

--- a/tests/Functional/FunctionalDbalTestCase.php
+++ b/tests/Functional/FunctionalDbalTestCase.php
@@ -16,7 +16,7 @@ namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal\Functional;
 use Doctrine\DBAL\Schema\Schema as DbSchema;
 use Doctrine\Tests\TestUtil;
 use Rollerworks\Component\Search\Doctrine\Dbal\EventSubscriber\SqliteConnectionSubscriber;
-use Rollerworks\Component\Search\Doctrine\Dbal\WhereBuilder;
+use Rollerworks\Component\Search\Doctrine\Dbal\WhereBuilderInterface;
 use Rollerworks\Component\Search\SearchCondition;
 use Rollerworks\Component\Search\Tests\Doctrine\Dbal\DbalTestCase;
 use Rollerworks\Component\Search\Tests\Doctrine\Dbal\SchemaRecord;
@@ -128,9 +128,9 @@ abstract class FunctionalDbalTestCase extends DbalTestCase
     /**
      * Configure fields of the WhereBuilder.
      *
-     * @param WhereBuilder $whereBuilder
+     * @param WhereBuilderInterface $whereBuilder
      */
-    protected function configureWhereBuilder(WhereBuilder $whereBuilder)
+    protected function configureWhereBuilder(WhereBuilderInterface $whereBuilder)
     {
     }
 
@@ -177,7 +177,7 @@ abstract class FunctionalDbalTestCase extends DbalTestCase
 
         $whereClause = $whereBuilder->getWhereClause();
 
-        $this->assertNotNull($this->conn->query($this->getQuery().$whereClause));
+        self::assertNotEmpty($this->conn->query($this->getQuery().$whereClause));
     }
 
     protected function onNotSuccessfulTest($e)

--- a/tests/Functional/WhereBuilderResultsTest.php
+++ b/tests/Functional/WhereBuilderResultsTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal\Functional;
 
 use Doctrine\DBAL\Schema\Schema as DbSchema;
-use Rollerworks\Component\Search\Doctrine\Dbal\WhereBuilder;
+use Rollerworks\Component\Search\Doctrine\Dbal\WhereBuilderInterface;
 use Rollerworks\Component\Search\Extension\Core\Type\BirthdayType;
 use Rollerworks\Component\Search\Extension\Core\Type\ChoiceType;
 use Rollerworks\Component\Search\Extension\Core\Type\DateType;
@@ -188,7 +188,7 @@ WHERE
 SQL;
     }
 
-    protected function configureWhereBuilder(WhereBuilder $whereBuilder)
+    protected function configureWhereBuilder(WhereBuilderInterface $whereBuilder)
     {
         // Customer (by invoice relation)
         $whereBuilder->setField('customer-first-name', 'first_name', 'c', 'string');

--- a/tests/ValueConversionStrategy.php
+++ b/tests/ValueConversionStrategy.php
@@ -13,13 +13,12 @@ declare(strict_types=1);
 
 namespace Rollerworks\Component\Search\Tests\Doctrine\Dbal;
 
-use Rollerworks\Component\Search\Doctrine\Dbal\ColumnConversion;
 use Rollerworks\Component\Search\Doctrine\Dbal\StrategySupportedConversion;
 use Rollerworks\Component\Search\Doctrine\Dbal\ValueConversion;
 
 /**
  * @internal
  */
-interface ValueConversionStrategy extends StrategySupportedConversion, ColumnConversion, ValueConversion
+interface ValueConversionStrategy extends StrategySupportedConversion, ValueConversion
 {
 }


### PR DESCRIPTION
* WhereBuilder caching now uses PSR-16 (SimpleCache) instead of Doctrine Cache
* Support for configuring a Cache has been removed, the Cache key is now automatically configured
  based on the FieldSet (name), serialized root ValuesGroup and Field mappings (exception field options)
* The CacheWhereBuilder can now be used directly for configuring (no more if statements)
* When no Cache implementation is provided caching is disabled rather then an exception is thrown
* Configuring Conversions on a WhereBuilder has been removed, the type options now require configuring the
  column/value conversion

Some minor bug fixes and corrections.

**Note:** Type conversion configuring was broken due to a wrong FieldType class-reference.